### PR TITLE
Make the tool available as a command line tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 *.pyo
 *.pyd
 
+dist
+build
 # Output file
 output.txt
 

--- a/.gptignore
+++ b/.gptignore
@@ -5,3 +5,5 @@ __pycache__/
 .gptignore
 LICENSE
 .github/*
+dist
+build

--- a/gpt_repository_loader.py
+++ b/gpt_repository_loader.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import fnmatch
+import pyperclip
 
 def get_ignore_list(ignore_file_path):
     ignore_list = []
@@ -58,4 +59,11 @@ if __name__ == "__main__":
     with open('output.txt', 'a') as output_file:
         output_file.write("--END--")
     print("Repository contents written to output.txt.")
+
+        # Copy the output to the clipboard if the -c flag is provided
+    if "-c" in sys.argv:
+        with open('output.txt', 'r') as output_file:
+            clipboard_contents = output_file.read()
+        pyperclip.copy(clipboard_contents)
+        print("Repository contents copied to clipboard.")
     

--- a/gpt_repository_loader/__init__.py
+++ b/gpt_repository_loader/__init__.py
@@ -1,0 +1,1 @@
+from .gpt_repository_loader import main

--- a/gpt_repository_loader/gpt_repository_loader.py
+++ b/gpt_repository_loader/gpt_repository_loader.py
@@ -31,7 +31,7 @@ def process_repository(repo_path, ignore_list, output_file):
                 output_file.write(f"{relative_file_path}\n")
                 output_file.write(f"{contents}\n")
 
-if __name__ == "__main__":
+def main():
     if len(sys.argv) < 2:
         print("Usage: python git_to_text.py /path/to/git/repository [-p /path/to/preamble.txt]")
         sys.exit(1)
@@ -66,4 +66,6 @@ if __name__ == "__main__":
             clipboard_contents = output_file.read()
         pyperclip.copy(clipboard_contents)
         print("Repository contents copied to clipboard.")
-    
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyperclip

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="gpt-repository-loader",
+    version="0.1.2",
+    author="Felvin",
+    author_email="team@felvin.com",
+    description="A utility to convert a Git repository into a text representation.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/felvin-search/gpt-repository-loader",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+    python_requires=">=3.6",
+    install_requires=["pyperclip"],
+    entry_points={
+        "console_scripts": [
+            "gpt-repository-loader=gpt_repository_loader:main",
+        ],
+    },
+)
+


### PR DESCRIPTION
Now there will be no need to clone the repo. `
pip install gpt-repository-loader
` will make the tool available across your system to be used with any repository.

Usage after pip install:
`gpt-repository-loader /path/to/repository`