### PR TITLE
Add negated-pattern support for .gptignore

### DIFF
--- a/gpt_repository_loader.py
+++ b/gpt_repository_loader.py
@@ -15,7 +15,11 @@ def get_ignore_list(ignore_file_path):
 
 def should_ignore(file_path, ignore_list):
     for pattern in ignore_list:
-        if fnmatch.fnmatch(file_path, pattern):
+        if pattern.startswith("!"):
+            negated_pattern = pattern[1:]  # Remove the negation prefix '!'
+            if fnmatch.fnmatch(file_path, negated_pattern):
+                return False
+        elif fnmatch.fnmatch(file_path, pattern):
             return True
     return False
 


### PR DESCRIPTION
I wanted to only process `.c` and `.h` files for instance:

```gitignore
!*.c
!*.h
*
```