### PR TITLE
Add .gptignore to README and add more types to ignore

### DIFF
--- a/.gptignore
+++ b/.gptignore
@@ -12,7 +12,27 @@ LICENSE
 *.tar.gz
 .gitignore
 *.env*
+*bin/*
+*.lock
+.prettierignore
+
+# Node.js
+node_modules/*
+submodules/*
+package-lock.json
+
+# Mac
+.DS_Store
+
+# Images
 *.png
 *.jpeg
 *.jpg
-*bin/*
+*.gif
+
+# Documents
+*.doc
+*.pdf
+*.xls
+*.csv
+*.tsv

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ To get started with `gpt-repository-loader`, follow these steps:
    ```bash
    python gpt_repository_loader.py /path/to/git/repository [-p /path/to/preamble.txt] [-o /path/to/output_file.txt]
    ```
-    Replace `/path/to/git/repository` with the path to the Git repository you want to process. Optionally, you can specify a preamble file with -p or an output file with -o. If not specified, the default output file will be named output.txt in the current directory.
+   Replace `/path/to/git/repository` with the path to the Git repository you want to process.
 
-5. The tool will generate an output.txt file containing the text representation of the repository. You can now use this file as input for AI language models or other text-based processing tasks.
+   Optionally, you can
+      - Specify a preamble file with -p or an output file with -o. If not specified, the default output file will be named output.txt in the current directory.
+      - Ignore file/types by copying `.gptignore` into `/path/to/git/repository` (same syntax as [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files))
+
+6. The tool will generate an output.txt file containing the text representation of the repository. You can now use this file as input for AI language models or other text-based processing tasks.
 
 ## Running Tests
 


### PR DESCRIPTION
Thank you, this is incredibly helpful! Ran into issues because node has a _massive_ irrelevant directory `node_modules`. Didn't realize there was ignore function until I read [the explanatory note](https://github.com/mpoon/gpt-repository-loader/discussions/18).

So to save others that pain, clarifying in the README and adding ignore for Node and a few other cases.